### PR TITLE
議案カードと検索UIにコンポーネントテストを追加する

### DIFF
--- a/web/src/app/dev/_lib/mock-data.ts
+++ b/web/src/app/dev/_lib/mock-data.ts
@@ -1,4 +1,5 @@
 import type {
+  BillContent,
   BillStatusEnum,
   BillWithContent,
 } from "@/features/bills/shared/types";
@@ -11,6 +12,23 @@ export const allBillStatuses: BillStatusEnum[] = [
   "enacted",
   "rejected",
 ];
+
+export function createMockBillContent(
+  overrides: Partial<BillContent> = {}
+): BillContent {
+  return {
+    id: "mock-content-001",
+    bill_id: "mock-bill-001",
+    title: "サンプル法案のタイトル",
+    summary:
+      "この法案は開発プレビュー用のサンプルデータです。法案の要約文がここに表示されます。実際のデータではありません。",
+    content: "# サンプルコンテンツ\n\n本文がここに入ります。",
+    difficulty_level: "normal",
+    created_at: "2026-02-15T00:00:00Z",
+    updated_at: "2026-02-15T00:00:00Z",
+    ...overrides,
+  };
+}
 
 const baseBill: BillWithContent = {
   id: "mock-bill-001",
@@ -34,17 +52,7 @@ const baseBill: BillWithContent = {
   use_knowledge_source_in_chat: false,
   created_at: "2026-02-15T00:00:00Z",
   updated_at: "2026-02-15T00:00:00Z",
-  bill_content: {
-    id: "mock-content-001",
-    bill_id: "mock-bill-001",
-    title: "サンプル法案のタイトル",
-    summary:
-      "この法案は開発プレビュー用のサンプルデータです。法案の要約文がここに表示されます。実際のデータではありません。",
-    content: "# サンプルコンテンツ\n\n本文がここに入ります。",
-    difficulty_level: "normal",
-    created_at: "2026-02-15T00:00:00Z",
-    updated_at: "2026-02-15T00:00:00Z",
-  },
+  bill_content: createMockBillContent(),
   tags: [
     { id: "tag-1", label: "経済" },
     { id: "tag-2", label: "環境" },

--- a/web/src/features/bills/client/components/bill-list/bill-card.test.tsx
+++ b/web/src/features/bills/client/components/bill-list/bill-card.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  createMockBill,
+  createMockBillContent,
+} from "@/app/dev/_lib/mock-data";
+import { BillCard } from "./bill-card";
+
+describe("BillCard", () => {
+  it("タイトルと概要を出す", () => {
+    render(
+      <BillCard
+        bill={createMockBill({
+          bill_content: createMockBillContent({
+            title: "ガソリン税を安くする法案",
+            summary: "ガソリンにかかる税金を下げる法案です。",
+          }),
+        })}
+      />
+    );
+
+    expect(screen.getByText("ガソリン税を安くする法案")).toBeInTheDocument();
+    expect(
+      screen.getByText("ガソリンにかかる税金を下げる法案です。")
+    ).toBeInTheDocument();
+  });
+
+  it("注目の議案にだけ注目バッジを出す", () => {
+    const { rerender } = render(
+      <BillCard bill={createMockBill({ is_featured: false })} />
+    );
+    expect(screen.queryByText(/注目/)).not.toBeInTheDocument();
+
+    rerender(<BillCard bill={createMockBill({ is_featured: true })} />);
+    expect(screen.getByText(/注目/)).toBeInTheDocument();
+  });
+
+  // staging で多くの議案がサムネイル未設定だった。無い側も崩れずに出る必要がある。
+  it("サムネイルが未設定なら画像を出さない", () => {
+    render(
+      <BillCard
+        bill={createMockBill({
+          name: "揮発油税等の暫定税率の廃止等に関する法律案",
+          thumbnail_url: null,
+        })}
+      />
+    );
+
+    // レビュー完了バッジも img なので、サムネイルの代替テキストで狙う。
+    expect(
+      screen.queryByRole("img", {
+        name: "揮発油税等の暫定税率の廃止等に関する法律案",
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it("サムネイルがあれば正式名称を代替テキストにして出す", () => {
+    render(
+      <BillCard
+        bill={createMockBill({
+          name: "揮発油税等の暫定税率の廃止等に関する法律案",
+          thumbnail_url: "https://example.com/thumb.png",
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole("img", {
+        name: "揮発油税等の暫定税率の廃止等に関する法律案",
+      })
+    ).toBeInTheDocument();
+  });
+
+  /*
+    サムネイルの有無で注目バッジの配置が absolute と relative に切り替わる。
+    切り替え先はクラス名にしか現れないので、ここでは両方が同時に出ることだけを
+    見る。重なり方そのものは目で見て確かめる。
+  */
+  it("サムネイルがあっても注目バッジを出す", () => {
+    render(
+      <BillCard
+        bill={createMockBill({
+          name: "揮発油税等の暫定税率の廃止等に関する法律案",
+          is_featured: true,
+          thumbnail_url: "https://example.com/thumb.png",
+        })}
+      />
+    );
+
+    expect(screen.getByText(/注目/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", {
+        name: "揮発油税等の暫定税率の廃止等に関する法律案",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("紐づくタグをすべて並べる", () => {
+    render(
+      <BillCard
+        bill={createMockBill({
+          tags: [
+            { id: "zeikin", label: "税金" },
+            { id: "kurashi", label: "暮らし" },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByText("税金")).toBeInTheDocument();
+    expect(screen.getByText("暮らし")).toBeInTheDocument();
+  });
+
+  it("公開インタビューがあるときだけ受付中を出す", () => {
+    const { rerender } = render(
+      <BillCard bill={createMockBill({ hasPublicInterview: false })} />
+    );
+    expect(screen.queryByText("AIインタビュー受付中")).not.toBeInTheDocument();
+
+    rerender(<BillCard bill={createMockBill({ hasPublicInterview: true })} />);
+    expect(screen.getByText("AIインタビュー受付中")).toBeInTheDocument();
+  });
+
+  it("レビュー完了のときだけ完了バッジを添える", () => {
+    const { rerender } = render(
+      <BillCard bill={createMockBill({ is_review_completed: false })} />
+    );
+    expect(
+      screen.queryByRole("img", { name: "レビュー完了" })
+    ).not.toBeInTheDocument();
+
+    rerender(<BillCard bill={createMockBill({ is_review_completed: true })} />);
+    expect(
+      screen.getByRole("img", { name: "レビュー完了" })
+    ).toBeInTheDocument();
+  });
+
+  it("提出日を time 要素で出す", () => {
+    const { container } = render(
+      <BillCard bill={createMockBill({ submitted_date: "2026-02-03" })} />
+    );
+
+    expect(container.querySelector("time")).toHaveTextContent("2026.2.3 提出");
+  });
+
+  /*
+    日付そのものの有無で見る。文字列で否定すると、同じカードにある
+    ステータスバッジの「法案提出前」「法案成立」まで拾ってしまう。
+  */
+  it("提出日が無ければ日付を出さない", () => {
+    const { container } = render(
+      <BillCard bill={createMockBill({ submitted_date: null })} />
+    );
+
+    expect(container.querySelector("time")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/bills/client/components/bill-list/bill-search-card.test.tsx
+++ b/web/src/features/bills/client/components/bill-list/bill-search-card.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  createMockBill,
+  createMockBillContent,
+} from "@/app/dev/_lib/mock-data";
+import { BillSearchCard } from "./bill-search-card";
+
+describe("BillSearchCard", () => {
+  it("カード全体が議案の詳細へのリンクになる", () => {
+    render(<BillSearchCard bill={createMockBill({ id: "bill-gasoline" })} />);
+
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/bills/bill-gasoline"
+    );
+  });
+
+  // 一覧では何の法案かが読めないと選べないので、タイトルは省略しない。
+  it("長いタイトルも省略せずに出す", () => {
+    const title =
+      "地方公共団体の議会の議員及び長の選挙に係る公職選挙法の特例に関する法律の一部を改正する法律案";
+    render(
+      <BillSearchCard
+        bill={createMockBill({
+          bill_content: createMockBillContent({ title }),
+        })}
+      />
+    );
+
+    expect(screen.getByRole("heading")).toHaveTextContent(title);
+  });
+
+  it("タイトルが無ければ正式名称を見出しにする", () => {
+    render(
+      <BillSearchCard
+        bill={createMockBill({
+          name: "学校給食法の一部を改正する法律案",
+          bill_content: undefined,
+          is_review_completed: false,
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "学校給食法の一部を改正する法律案" })
+    ).toBeInTheDocument();
+  });
+
+  it("概要があれば添え、無ければ何も出さない", () => {
+    const { rerender } = render(
+      <BillSearchCard
+        bill={createMockBill({
+          bill_content: createMockBillContent({ summary: "税金を下げます。" }),
+        })}
+      />
+    );
+    expect(screen.getByText("税金を下げます。")).toBeInTheDocument();
+
+    rerender(
+      <BillSearchCard bill={createMockBill({ bill_content: undefined })} />
+    );
+    expect(screen.queryByText("税金を下げます。")).not.toBeInTheDocument();
+  });
+
+  /*
+    サムネイルはリンクの中の飾りなので alt を空にしている。読み上げは見出しの
+    タイトルが担う。同じ内容を二度読ませない。
+  */
+  it("サムネイルは読み上げ対象にしない", () => {
+    const { container } = render(
+      <BillSearchCard
+        bill={createMockBill({
+          thumbnail_url: "https://example.com/thumb.png",
+        })}
+      />
+    );
+
+    const thumbnail = container.querySelector('img[alt=""]');
+    expect(thumbnail).toBeInTheDocument();
+  });
+
+  // staging で多くの議案がサムネイル未設定だった。無い側も崩れずに出る必要がある。
+  it("サムネイルが未設定なら画像を出さない", () => {
+    const { container } = render(
+      <BillSearchCard bill={createMockBill({ thumbnail_url: null })} />
+    );
+
+    expect(container.querySelector('img[alt=""]')).not.toBeInTheDocument();
+  });
+
+  it("提出日があるときだけ日付を出す", () => {
+    const { rerender } = render(
+      <BillSearchCard bill={createMockBill({ submitted_date: "2026-02-03" })} />
+    );
+    expect(screen.getByText("2026.2.3 提出")).toBeInTheDocument();
+
+    rerender(
+      <BillSearchCard bill={createMockBill({ submitted_date: null })} />
+    );
+    expect(
+      screen.queryByText(/^\d{4}\.\d+\.\d+ 提出$/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("タグ・受付中・回答数が無ければ下の段ごと出さない", () => {
+    render(
+      <BillSearchCard
+        bill={createMockBill({
+          tags: [],
+          hasPublicInterview: false,
+          publicReportCount: 0,
+        })}
+      />
+    );
+
+    expect(screen.queryByText("AIインタビュー受付中")).not.toBeInTheDocument();
+    expect(screen.queryByText(/回答/)).not.toBeInTheDocument();
+  });
+
+  it("タグと受付中を下の段に並べる", () => {
+    render(
+      <BillSearchCard
+        bill={createMockBill({
+          tags: [{ id: "zeikin", label: "税金" }],
+          hasPublicInterview: true,
+        })}
+      />
+    );
+
+    expect(screen.getByText("税金")).toBeInTheDocument();
+    expect(screen.getByText("AIインタビュー受付中")).toBeInTheDocument();
+  });
+
+  // 0人と書くと参加をためらわせるので、集まっている議案にだけ数字を出す。
+  it("回答が集まっている議案にだけ回答数を出す", () => {
+    const { rerender } = render(
+      <BillSearchCard bill={createMockBill({ publicReportCount: 0 })} />
+    );
+    expect(
+      screen.queryByText(/人がAIインタビューに回答/)
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <BillSearchCard bill={createMockBill({ publicReportCount: 12 })} />
+    );
+    expect(screen.getByText(/12人がAIインタビューに回答/)).toBeInTheDocument();
+  });
+
+  it("レビュー完了のときだけ完了バッジを添える", () => {
+    const { rerender } = render(
+      <BillSearchCard bill={createMockBill({ is_review_completed: false })} />
+    );
+    expect(
+      screen.queryByRole("img", { name: "レビュー完了" })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <BillSearchCard bill={createMockBill({ is_review_completed: true })} />
+    );
+    expect(
+      screen.getByRole("img", { name: "レビュー完了" })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/bills/client/components/bill-list/compact-bill-card.test.tsx
+++ b/web/src/features/bills/client/components/bill-list/compact-bill-card.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  createMockBill,
+  createMockBillContent,
+} from "@/app/dev/_lib/mock-data";
+import { CompactBillCard } from "./compact-bill-card";
+
+/** 日付の行だけを狙う。行全体に一致させて、ステータスバッジの文言と混ざらないようにする。 */
+const DATE_LINE = /^\d{4}\.\d+\.\d+ (提出|成立)$/;
+
+describe("CompactBillCard", () => {
+  it("わかりやすいタイトルがあればそれを見出しにする", () => {
+    render(
+      <CompactBillCard
+        bill={createMockBill({
+          bill_content: createMockBillContent({
+            title: "給食を無償にする法案",
+          }),
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /給食を無償にする法案/ })
+    ).toBeInTheDocument();
+  });
+
+  /*
+    カードの取得は bill_contents!inner なので、この経路は通常は通らない。
+    フォールバックが消えたときに見出しが空になるのを防ぐための保険。
+  */
+  it("タイトルが無ければ正式名称を見出しにする", () => {
+    render(
+      <CompactBillCard
+        bill={createMockBill({
+          name: "学校給食法の一部を改正する法律案",
+          bill_content: undefined,
+          is_review_completed: false,
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "学校給食法の一部を改正する法律案" })
+    ).toBeInTheDocument();
+  });
+
+  it("レビュー完了のときだけ完了バッジを添える", () => {
+    const { rerender } = render(
+      <CompactBillCard bill={createMockBill({ is_review_completed: false })} />
+    );
+    expect(
+      screen.queryByRole("img", { name: "レビュー完了" })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <CompactBillCard bill={createMockBill({ is_review_completed: true })} />
+    );
+    expect(
+      screen.getByRole("img", { name: "レビュー完了" })
+    ).toBeInTheDocument();
+  });
+
+  it("成立済みの日付には「成立」を添える", () => {
+    render(
+      <CompactBillCard
+        bill={createMockBill({
+          status: "enacted",
+          submitted_date: "2026-02-03",
+        })}
+      />
+    );
+
+    expect(screen.getByText(DATE_LINE)).toHaveTextContent("2026.2.3 成立");
+  });
+
+  it("成立していなければ「提出」を添える", () => {
+    render(
+      <CompactBillCard
+        bill={createMockBill({
+          status: "introduced",
+          submitted_date: "2026-02-03",
+        })}
+      />
+    );
+
+    expect(screen.getByText(DATE_LINE)).toHaveTextContent("2026.2.3 提出");
+  });
+
+  // 成立済みでも日付が無いことはある。バッジの「法案成立」と取り違えない。
+  it("日付が無ければ日付の行を出さない", () => {
+    render(
+      <CompactBillCard
+        bill={createMockBill({ status: "enacted", submitted_date: null })}
+      />
+    );
+
+    expect(screen.queryByText(DATE_LINE)).not.toBeInTheDocument();
+  });
+
+  // staging で多くの議案がサムネイル未設定だった。無い側も崩れずに出る必要がある。
+  it("サムネイルが未設定なら画像を出さない", () => {
+    render(
+      <CompactBillCard
+        bill={createMockBill({
+          name: "揮発油税等の暫定税率の廃止等に関する法律案",
+          thumbnail_url: null,
+        })}
+      />
+    );
+
+    // レビュー完了バッジも img なので、サムネイルの代替テキストで狙う。
+    expect(
+      screen.queryByRole("img", {
+        name: "揮発油税等の暫定税率の廃止等に関する法律案",
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it("サムネイルがあれば正式名称を代替テキストにして出す", () => {
+    render(
+      <CompactBillCard
+        bill={createMockBill({
+          name: "揮発油税等の暫定税率の廃止等に関する法律案",
+          thumbnail_url: "https://example.com/thumb.png",
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole("img", {
+        name: "揮発油税等の暫定税率の廃止等に関する法律案",
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/bills/client/components/bill-search-overlay.test.tsx
+++ b/web/src/features/bills/client/components/bill-search-overlay.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BillSearchOverlay } from "./bill-search-overlay";
+
+const pushMock = vi.hoisted(() => vi.fn());
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: pushMock }) }));
+
+const tags = [
+  { id: "kurashi", label: "暮らし", count: 8 },
+  { id: "zeikin", label: "税金", count: 3 },
+];
+
+const bills = [
+  {
+    id: "bill-gasoline",
+    name: "揮発油税等の暫定税率の廃止等に関する法律案",
+    bill_content: { title: "ガソリン税を安くする法案" },
+    tags: [{ id: "zeikin", label: "税金" }],
+  },
+  {
+    id: "bill-school",
+    name: "学校給食法の一部を改正する法律案",
+    bill_content: { title: "給食を無償にする法案" },
+    tags: [{ id: "kurashi", label: "暮らし" }],
+  },
+];
+
+async function open() {
+  const user = userEvent.setup();
+  render(<BillSearchOverlay tags={tags} bills={bills} />);
+  await user.click(screen.getByRole("button", { name: /法案を検索する/ }));
+  return user;
+}
+
+/** 候補のリンクはタイトルが一致箇所で割れるので、リンク先で特定する。 */
+function linkTo(href: string) {
+  return screen
+    .getAllByRole("link")
+    .filter((link) => link.getAttribute("href") === href);
+}
+
+/** push された遷移先のクエリを読む。エンコード済みの文字列とは比べない。 */
+function pushedParam(name: string) {
+  const href = pushMock.mock.calls.at(-1)?.[0] as string;
+  return new URL(href, "http://localhost").searchParams.get(name);
+}
+
+beforeEach(() => {
+  pushMock.mockClear();
+});
+
+describe("BillSearchOverlay", () => {
+  it("入力前は候補を出さず、テーマだけを見せる", async () => {
+    await open();
+
+    expect(screen.getByText("テーマから探す")).toBeInTheDocument();
+    expect(screen.queryByText(/法案\s*\d+件/)).not.toBeInTheDocument();
+  });
+
+  /*
+    タイトルがあるだけでは読み上げに使われない。説明が欠けると Radix が警告を
+    出すが警告は素通りするので、ここで固定する。
+  */
+  it("読み上げ向けの説明を持つ", async () => {
+    await open();
+
+    expect(screen.getByRole("dialog")).toHaveAccessibleDescription(
+      "キーワードやテーマから法案を探せます。"
+    );
+  });
+
+  it("入力すると一致した候補と件数を出す", async () => {
+    const user = await open();
+
+    await user.type(screen.getByRole("searchbox"), "ガソリン");
+
+    expect(screen.getByText(/法案\s*1件/)).toBeInTheDocument();
+
+    const links = linkTo("/bills/bill-gasoline");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent("ガソリン税を安くする法案");
+  });
+
+  // 候補は名称・タイトル・タグ名だけを見る。要約は渡していない。
+  it("タグ名でも候補に出る", async () => {
+    const user = await open();
+
+    await user.type(screen.getByRole("searchbox"), "暮らし");
+
+    expect(linkTo("/bills/bill-school")).toHaveLength(1);
+  });
+
+  // 一覧の検索は要約も見るので、候補が空でも結果が出ることがある。
+  it("一致しなければ候補が無いことを伝える", async () => {
+    const user = await open();
+
+    await user.type(screen.getByRole("searchbox"), "宇宙");
+
+    expect(
+      screen.getByText(/「宇宙」に一致する候補はありません/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/法案\s*\d+件/)).not.toBeInTheDocument();
+  });
+
+  it("送信すると前後の空白を落として一覧へ渡す", async () => {
+    const user = await open();
+
+    await user.type(screen.getByRole("searchbox"), "  ガソリン  ");
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    expect(pushedParam("q")).toBe("ガソリン");
+  });
+
+  it("送信するとモーダルを閉じる", async () => {
+    const user = await open();
+
+    await user.type(screen.getByRole("searchbox"), "ガソリン");
+    await user.click(screen.getByRole("button", { name: "検索" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  // 遷移先が同じ一覧ページのときもあるので、開いたままだと中身が隠れる。
+  it("候補を選ぶとモーダルを閉じる", async () => {
+    const user = await open();
+
+    await user.type(screen.getByRole("searchbox"), "ガソリン");
+    await user.click(linkTo("/bills/bill-gasoline")[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("テーマのチップは一覧をタグで絞ったURLに向き、選ぶと閉じる", async () => {
+    const user = await open();
+    const chip = screen.getByRole("link", { name: /暮らし/ });
+
+    expect(chip).toHaveAttribute("href", "/bills?tag=kurashi");
+
+    await user.click(chip);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("閉じるボタンでモーダルを閉じる", async () => {
+    const user = await open();
+
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/features/bills/client/components/bill-search-overlay.tsx
+++ b/web/src/features/bills/client/components/bill-search-overlay.tsx
@@ -9,6 +9,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
@@ -84,6 +85,9 @@ export function BillSearchOverlay({
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">法案を検索</DialogTitle>
+        <DialogDescription className="sr-only">
+          キーワードやテーマから法案を探せます。
+        </DialogDescription>
 
         <div className="flex justify-end px-2 pt-2">
           <DialogClose

--- a/web/src/features/bills/client/components/category-tab-scroller.test.tsx
+++ b/web/src/features/bills/client/components/category-tab-scroller.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveScrollStep } from "../utils/scroll-affordance";
+import { CategoryTabScroller } from "./category-tab-scroller";
+
+/*
+  矢印を出すかどうかの判定そのものは resolveScrollAffordance のテストで見ている。
+  ここで見るのはコンポーネント側の配線、つまり「どの契機で再判定が走るか」
+  「どれだけ送るか」「監視を張って外すか」。
+
+  jsdom は要素の寸法を持たず clientWidth も scrollWidth も常に 0 を返すので、
+  判定に使う3つの値を差し替えて動かす。
+*/
+type Metrics = { scrollLeft: number; clientWidth: number; scrollWidth: number };
+
+/** 中身が右にはみ出していて、右にだけ送れる状態。 */
+const OVERFLOWING: Metrics = {
+  scrollLeft: 0,
+  clientWidth: 300,
+  scrollWidth: 1000,
+};
+
+let resizeCallbacks: ResizeObserverCallback[];
+let observed: Element[];
+let disconnectCount: number;
+let scrollBySpy: ReturnType<typeof vi.fn>;
+let reduceMotion: boolean;
+
+beforeEach(() => {
+  resizeCallbacks = [];
+  observed = [];
+  disconnectCount = 0;
+  reduceMotion = false;
+
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback);
+      }
+      observe(target: Element) {
+        observed.push(target);
+      }
+      unobserve() {}
+      disconnect() {
+        disconnectCount += 1;
+      }
+    }
+  );
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches: query.includes("prefers-reduced-motion") && reduceMotion,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+
+  // jsdom は scrollBy を持たないので spyOn できない。生やして afterEach で消す。
+  scrollBySpy = vi.fn();
+  Element.prototype.scrollBy = scrollBySpy;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(Element.prototype, "scrollBy");
+});
+
+function setup() {
+  const view = render(
+    <CategoryTabScroller>
+      <div data-testid="tabs">タブ</div>
+    </CategoryTabScroller>
+  );
+
+  // タブ → 中身のラッパー → スクロールする枠。class ではなく構造で辿る。
+  const content = screen.getByTestId("tabs").parentElement;
+  const viewport = content?.parentElement;
+  if (!content || !viewport) {
+    throw new Error("スクローラーの構造が変わっている");
+  }
+
+  const apply = (metrics: Metrics) => {
+    for (const [key, value] of Object.entries(metrics)) {
+      Object.defineProperty(viewport, key, { value, configurable: true });
+    }
+  };
+
+  /** 幅が変わったときの経路。 */
+  const resize = (metrics: Metrics) => {
+    apply(metrics);
+    act(() => {
+      for (const callback of resizeCallbacks) {
+        callback([], {} as ResizeObserver);
+      }
+    });
+  };
+
+  /** スクロール操作の経路。 */
+  const scroll = (metrics: Metrics) => {
+    apply(metrics);
+    fireEvent.scroll(viewport);
+  };
+
+  return {
+    left: screen.getByRole("button", { name: "カテゴリを左に送る" }),
+    right: screen.getByRole("button", { name: "カテゴリを右に送る" }),
+    content,
+    viewport,
+    resize,
+    scroll,
+    unmount: view.unmount,
+  };
+}
+
+describe("CategoryTabScroller", () => {
+  it("中身が収まっているうちはどちらにも送れない", () => {
+    const { left, right } = setup();
+
+    expect(left).toBeDisabled();
+    expect(right).toBeDisabled();
+  });
+
+  /*
+    画面幅とタブの並び幅のどちらでも判定が変わる。フォントの読み込みやタブの
+    件数の変化で中身の幅だけが動くこともあるので、両方を監視する。
+  */
+  it("枠と中身の両方の寸法を監視する", () => {
+    const { content, viewport } = setup();
+
+    expect(observed).toContain(viewport);
+    expect(observed).toContain(content);
+  });
+
+  it("外したときに監視をやめる", () => {
+    const { unmount } = setup();
+
+    expect(disconnectCount).toBe(0);
+    unmount();
+    expect(disconnectCount).toBe(1);
+  });
+
+  it("幅が変わると矢印を出し直す", () => {
+    const { right, resize } = setup();
+
+    expect(right).toBeDisabled();
+    resize(OVERFLOWING);
+    expect(right).toBeEnabled();
+  });
+
+  it("スクロールすると矢印を出し直す", () => {
+    const { left, right, scroll } = setup();
+
+    scroll({ scrollLeft: 700, clientWidth: 300, scrollWidth: 1000 });
+
+    expect(left).toBeEnabled();
+    expect(right).toBeDisabled();
+  });
+
+  it("見えている範囲を基準に送り、向きで符号が変わる", async () => {
+    const user = userEvent.setup();
+    const { left, right, scroll } = setup();
+
+    scroll({ scrollLeft: 350, clientWidth: 300, scrollWidth: 1000 });
+
+    await user.click(right);
+    expect(scrollBySpy).toHaveBeenLastCalledWith({
+      left: resolveScrollStep(300, 1),
+      behavior: "smooth",
+    });
+
+    await user.click(left);
+    expect(scrollBySpy).toHaveBeenLastCalledWith({
+      left: resolveScrollStep(300, -1),
+      behavior: "smooth",
+    });
+  });
+
+  it("動きを減らす設定ではアニメーションなしで送る", async () => {
+    reduceMotion = true;
+    const user = userEvent.setup();
+    const { right, resize } = setup();
+
+    resize(OVERFLOWING);
+    await user.click(right);
+
+    expect(scrollBySpy).toHaveBeenLastCalledWith({
+      left: resolveScrollStep(300, 1),
+      behavior: "auto",
+    });
+  });
+
+  // 押し切った瞬間にボタンが消えると、キーボードのフォーカスが body に落ちる。
+  it("送れない向きの矢印も DOM から消さない", () => {
+    const { left, right, resize } = setup();
+
+    resize(OVERFLOWING);
+
+    expect(left).toBeDisabled();
+    expect(left).toBeInTheDocument();
+    expect(right).toBeInTheDocument();
+  });
+});

--- a/web/src/features/bills/client/components/category-tab-scroller.tsx
+++ b/web/src/features/bills/client/components/category-tab-scroller.tsx
@@ -9,10 +9,10 @@ import {
   useState,
 } from "react";
 import { Button } from "@/components/ui/button";
-import { resolveScrollAffordance } from "../utils/scroll-affordance";
-
-/** 1回の送り幅。見えている範囲を基準にすると、幅が変わっても送りすぎない。 */
-const SCROLL_RATIO = 0.8;
+import {
+  resolveScrollAffordance,
+  resolveScrollStep,
+} from "../utils/scroll-affordance";
 
 /**
  * カテゴリタブの横スクロール。
@@ -62,7 +62,7 @@ export function CategoryTabScroller({ children }: { children: ReactNode }) {
     ).matches;
 
     el.scrollBy({
-      left: direction * el.clientWidth * SCROLL_RATIO,
+      left: resolveScrollStep(el.clientWidth, direction),
       behavior: reduceMotion ? "auto" : "smooth",
     });
   };

--- a/web/src/features/bills/client/utils/scroll-affordance.test.ts
+++ b/web/src/features/bills/client/utils/scroll-affordance.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveScrollAffordance } from "./scroll-affordance";
+import {
+  resolveScrollAffordance,
+  resolveScrollStep,
+} from "./scroll-affordance";
 
 describe("resolveScrollAffordance", () => {
   it("中身が収まっていればどちらも出さない", () => {
@@ -80,5 +83,19 @@ describe("resolveScrollAffordance", () => {
         scrollWidth: 0,
       })
     ).toEqual({ canScrollLeft: false, canScrollRight: false });
+  });
+});
+
+describe("resolveScrollStep", () => {
+  it("見えている範囲の8割を送る", () => {
+    expect(resolveScrollStep(300, 1)).toBe(240);
+  });
+
+  it("左送りは符号が反転する", () => {
+    expect(resolveScrollStep(300, -1)).toBe(-240);
+  });
+
+  it("測定前の0では動かさない", () => {
+    expect(resolveScrollStep(0, 1)).toBe(0);
   });
 });

--- a/web/src/features/bills/client/utils/scroll-affordance.ts
+++ b/web/src/features/bills/client/utils/scroll-affordance.ts
@@ -23,3 +23,14 @@ export function resolveScrollAffordance({
     canScrollRight: scrollLeft + clientWidth < scrollWidth - EDGE_SLACK_PX,
   };
 }
+
+/** 1回の送り幅の比率。見えている範囲を基準にすると、幅が変わっても送りすぎない。 */
+export const SCROLL_STEP_RATIO = 0.8;
+
+/** 送り1回ぶんの移動量。右送りが正、左送りが負。 */
+export function resolveScrollStep(
+  clientWidth: number,
+  direction: 1 | -1
+): number {
+  return direction * clientWidth * SCROLL_STEP_RATIO;
+}


### PR DESCRIPTION
UI 系の PR で `codecov/patch`（目標80%）が落ち続けていた件の対応です。原因は対象のコンポーネントにテストが1つも無かったことでした。

## 変更

テストの無かった5コンポーネントを埋めました。statements はいずれも 0% からの値です。

| ファイル | statements | branch |
|---|---|---|
| `bill-search-overlay.tsx` | 100% | 94.1% |
| `bill-search-card.tsx` | 100% | 100% |
| `bill-card.tsx` | 100% | 90% |
| `compact-bill-card.tsx` | 100% | 100% |
| `category-tab-scroller.tsx` | 100% | 85.7% |

テストを書く過程で見つかったものを2つ直しています。

**検索モーダルに読み上げ向けの説明がありませんでした。** `DialogContent` に説明が無く Radix が警告を出していたので `DialogDescription` を追加しました。警告は素通りするため、テストで固定しています。

**送り幅の計算を純粋関数に切り出しました。** `resolveScrollStep` として `scroll-affordance.ts` に置き、単体テストを付けています。

議案のテストデータは、開発プレビューの `createMockBill` を使い回しました。新しいフィクスチャを作ると `bills` の全カラムを二重に列挙することになるためです。あわせて `createMockBillContent` を切り出しています。

## 別途対応したいこと

`DialogContent` を使う web 側の6コンポーネントに同じ説明の欠落が残っています。admin 側は全て持っているので web だけの状態です。このPRのスコープ外にしました。

- `restart-confirm-dialog.tsx`
- `interview-consent-modal.tsx`
- `make-public-modal.tsx`
- `make-private-modal.tsx`
- `expert-registration-modal.tsx`
- `interview-public-consent-modal.tsx`

## 確認したこと

`pnpm lint` / `pnpm typecheck` / `pnpm build` / `pnpm test` がローカルで通ることを確認しました。web は141ファイル・1,183件です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 検索モーダルにスクリーンリーダー向けの説明を追加し、アクセシビリティを向上しました。
  - カテゴリータブの左右スクロール量を最適化し、表示幅に応じて快適に移動できるよう改善しました。
  - reduced-motion 設定時のスクロール挙動にも対応しました。

- **テスト**
  - 法案カード、検索カード、検索モーダル、カテゴリータブの表示・操作に関するテストを追加しました。
  - サムネイル、日付、タグ、バッジなど各表示条件を幅広く検証しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->