### PR TITLE
難易度トグルのラベルを「説明をもっと詳しく」に固定する

### DIFF
--- a/web/src/features/bill-difficulty/client/components/difficulty-selector.test.tsx
+++ b/web/src/features/bill-difficulty/client/components/difficulty-selector.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DifficultySelector } from "./difficulty-selector";
+
+/*
+  切り替えたあとに押す先が変わったように見えるのを避けるため、
+  文言は難易度によらず「説明をもっと詳しく」で固定する。
+  ここではその固定と、トグルのオンオフが難易度に対応することを見る。
+*/
+describe("DifficultySelector", () => {
+  it("normalでもhardでも同じラベルを出す", () => {
+    const { unmount } = render(<DifficultySelector currentLevel="normal" />);
+    expect(screen.getByText("説明をもっと")).toBeInTheDocument();
+    expect(screen.getByText("詳しく")).toBeInTheDocument();
+    unmount();
+
+    render(<DifficultySelector currentLevel="hard" />);
+    expect(screen.getByText("説明をもっと")).toBeInTheDocument();
+    expect(screen.getByText("詳しく")).toBeInTheDocument();
+  });
+
+  it("hardのときだけトグルがオンになる", () => {
+    const { unmount } = render(<DifficultySelector currentLevel="normal" />);
+    expect(
+      screen.getByRole("switch", { name: "説明をもっと詳しく" })
+    ).not.toBeChecked();
+    unmount();
+
+    render(<DifficultySelector currentLevel="hard" />);
+    expect(
+      screen.getByRole("switch", { name: "説明をもっと詳しく" })
+    ).toBeChecked();
+  });
+});

--- a/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
+++ b/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
@@ -10,10 +10,6 @@ import {
   useRestoreScrollFromBottom,
 } from "../hooks/use-scroll-from-bottom";
 
-// トグルの状態によらず文言は固定する
-const LABEL_PREFIX = "説明をもっと";
-const LABEL_SUFFIX = "詳しく";
-
 interface DifficultySelectorProps {
   currentLevel: DifficultyLevelEnum;
   labelStyle?: CSSProperties;
@@ -74,18 +70,17 @@ export function DifficultySelector({
 
   return (
     <div className="flex items-center gap-2">
+      {/* 幅の狭い画面では「説明をもっと」を隠して「詳しく」だけ出す */}
       <span className="text-sm font-bold" style={labelStyle}>
-        <span>
-          <span className="hidden md:inline-block">{LABEL_PREFIX}</span>
-          {LABEL_SUFFIX}
-        </span>
+        <span className="hidden md:inline-block">説明をもっと</span>
+        詳しく
       </span>
       <Switch
         id={`${uniqueId}-difficulty-toggle`}
         checked={selectedLevel === "hard"}
         onCheckedChange={handleToggle}
         disabled={isChanging}
-        aria-label={`${LABEL_PREFIX}${LABEL_SUFFIX}`}
+        aria-label="説明をもっと詳しく"
       />
     </div>
   );

--- a/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
+++ b/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
@@ -10,6 +10,10 @@ import {
   useRestoreScrollFromBottom,
 } from "../hooks/use-scroll-from-bottom";
 
+// トグルの状態によらず文言は固定する
+const LABEL_PREFIX = "説明をもっと";
+const LABEL_SUFFIX = "詳しく";
+
 interface DifficultySelectorProps {
   currentLevel: DifficultyLevelEnum;
   labelStyle?: CSSProperties;
@@ -68,21 +72,12 @@ export function DifficultySelector({
     }
   };
 
-  const [labelPrefix, labelSuffix] =
-    selectedLevel === "hard"
-      ? ["説明を", "やさしく"]
-      : ["説明をもっと", "詳しく"];
-
   return (
     <div className="flex items-center gap-2">
-      {/*
-        文言は押したときに起きることを表す。詳しい版を読んでいるのに
-        「もっと詳しく」と出ていると、押す先がどちらなのか読み取れない。
-      */}
       <span className="text-sm font-bold" style={labelStyle}>
         <span>
-          <span className="hidden md:inline-block">{labelPrefix}</span>
-          {labelSuffix}
+          <span className="hidden md:inline-block">{LABEL_PREFIX}</span>
+          {LABEL_SUFFIX}
         </span>
       </span>
       <Switch
@@ -90,7 +85,7 @@ export function DifficultySelector({
         checked={selectedLevel === "hard"}
         onCheckedChange={handleToggle}
         disabled={isChanging}
-        aria-label={`${labelPrefix}${labelSuffix}`}
+        aria-label={`${LABEL_PREFIX}${LABEL_SUFFIX}`}
       />
     </div>
   );

--- a/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
+++ b/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
@@ -70,7 +70,6 @@ export function DifficultySelector({
 
   return (
     <div className="flex items-center gap-2">
-      {/* 幅の狭い画面では「説明をもっと」を隠して「詳しく」だけ出す */}
       <span className="text-sm font-bold" style={labelStyle}>
         <span className="hidden md:inline-block">説明をもっと</span>
         詳しく


### PR DESCRIPTION
## 概要

難易度トグルのラベルが押すたびに「説明をやさしく」と「説明をもっと詳しく」で入れ替わっていたため、常に「説明をもっと詳しく」を表示するようにしました。

[Slackでの指摘](https://team-mirai-staff.slack.com/archives/C0AFPQKSKS7/p1787709594695149?thread_ts=1786957796.961379&cid=C0AFPQKSKS7)

## 変更内容

- `DifficultySelector` のラベルを難易度によらず固定
  - 表示文言・`aria-label` ともに「説明をもっと詳しく」
  - モバイルで「説明をもっと」を隠す既存の折り返しはそのまま
- ラベル固定とトグルのオンオフを検証するコンポーネントテストを追加

## 動作確認

- `pnpm lint` / `pnpm typecheck`
- `npx vitest run --root web`（142 files / 1185 tests pass）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * 法案の説明切り替えラベルを「説明をもっと詳しく」に統一しました。
  * 狭い画面ではラベルの一部を省略し、「詳しく」と表示します。
  * ハードモードではトグルがオンになり、通常モードではオフになる表示を確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->