### PR TITLE
AIチャットのモデルをgpt-5.4-mini-fastに変更

### DIFF
--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -17,6 +17,7 @@ export const AI_MODELS = {
   gpt5_1_instant: "openai/gpt-5.1-instant",
   gpt5_1_thinking: "openai/gpt-5.1-thinking",
   gpt5_2: "openai/gpt-5.2",
+  gpt5_4_mini_fast: "openai/gpt-5.4-mini-fast",
   gpt5_6_sol: "openai/gpt-5.6-sol",
   gpt5_6_terra: "openai/gpt-5.6-terra",
   gpt5_6_luna: "openai/gpt-5.6-luna",

--- a/web/src/features/chat/server/services/handle-chat-request.ts
+++ b/web/src/features/chat/server/services/handle-chat-request.ts
@@ -100,7 +100,7 @@ export async function handleChatRequest({
     promptProvider
   );
   // Model configuration
-  const model = deps?.model ?? AI_MODELS.gpt4o;
+  const model = deps?.model ?? AI_MODELS.gpt5_6_terra;
   const modelName =
     typeof model === "string" ? model : (model.modelId ?? "unknown");
 

--- a/web/src/features/chat/server/services/handle-chat-request.ts
+++ b/web/src/features/chat/server/services/handle-chat-request.ts
@@ -100,7 +100,7 @@ export async function handleChatRequest({
     promptProvider
   );
   // Model configuration
-  const model = deps?.model ?? AI_MODELS.gpt5_6_terra;
+  const model = deps?.model ?? AI_MODELS.gpt5_4_mini_fast;
   const modelName =
     typeof model === "string" ? model : (model.modelId ?? "unknown");
 

--- a/web/src/lib/ai/calculate-ai-cost.ts
+++ b/web/src/lib/ai/calculate-ai-cost.ts
@@ -70,6 +70,10 @@ export const modelPricing: Record<string, ModelPricing> = {
     inputTokensPerMillionUsd: 1.75,
     outputTokensPerMillionUsd: 14,
   },
+  [AI_MODELS.gpt5_4_mini_fast]: {
+    inputTokensPerMillionUsd: 1.5,
+    outputTokensPerMillionUsd: 9,
+  },
   [AI_MODELS.gpt5_6_sol]: {
     inputTokensPerMillionUsd: 5,
     outputTokensPerMillionUsd: 30,


### PR DESCRIPTION
## 概要

サイトのAIチャット（`/api/chat`）の既定モデルを `openai/gpt-4o` → `openai/gpt-5.4-mini-fast` に変更します。

`AI_MODELS` には gpt-5.6 系まで登録済みで、モデレーション・充実度評価・意見バックフィルは既に `gpt-5.2` へ移行済みでしたが、ユーザーが最も触るサイトのAIチャットだけ gpt-4o のまま取り残されていました。

## 変更内容

- `handle-chat-request.ts`: 既定モデルを `AI_MODELS.gpt5_4_mini_fast` に変更
- `packages/shared/src/ai/models.ts`: `gpt5_4_mini_fast` を追加
- `calculate-ai-cost.ts`: `gpt5_4_mini_fast` の価格を追加（入力 $1.5/M・出力 $9/M）

既存テストは `deps.model` にモックを注入しているため、デフォルトモデルを assert している箇所はなく、テストの変更は不要でした。

## モデル選定の根拠（実測）

本番と同じ system prompt・同じ `openai.tools.webSearch()` 構成で、本番 open-data API から取得した実議案を埋め込み、AI Gateway 経由で比較しました。

### 速度・分量

| 質問 | モデル | TTFT | 完了 | 検索 | 字数 |
|---|---|---|---|---|---|
| この法案のポイントは？ | **gpt-5.4-mini-fast** | **0.8s** | **1.7s** | 0 | 361 |
| | gpt-5.6-terra | 0.8s | 4.0s | 0 | 440 |
| | gpt-4o | 1.0s | 4.2s | 0 | 387 |
| この法案は私にどんな影響がある？ | **gpt-5.4-mini-fast** | **0.7s** | **1.9s** | 0 | 424 |
| | gpt-5.6-terra | 1.8s | 4.7s | 0 | 418 |
| | gpt-4o | 0.9s | 3.3s | 0 | 442 |
| 審議状況や各党の反応を調べて（検索あり） | **gpt-5.4-mini-fast** | **2.6s** | **3.3s** | 1 | 875 |
| | gpt-5.6-terra | 21.4s | 26.1s | 7 | 1,074 |
| | gpt-4o | 5.9s | 11.3s | 1 | 2,056 |

### 選定理由

**gpt-4o を外す理由**

- 検索ありの質問で **2,056字**。`COMMON_RULES` の「回答は600文字以下を目安」の3.4倍で、指示追従が最も弱い
- 出典に **Reddit のスレッドと個人 note** を混ぜていた。中立性を掲げるプラットフォームの出典としては品質が低い
- 速度面でも優位がない（検索ありの TTFT は mini-fast の 2.6s に対し 5.9s）

**gpt-5.6-terra を採らない理由**

回答の正確さは最も高く、衆法24号・6/24提出・7/9付託・7/24閉会中審査まで特定し、「採決はまだなく、各党の最終的な賛否も記録されていません」と不明な点を明示する良い挙動でした。ただし検索を **7回** 実行して TTFT 21.4秒に達し、しかも検索回数のブレが大きく（別計測では2回・6.9秒）最悪ケースが読めません。検索中はUIに何も表示されないため、体感はさらに悪化します。

**gpt-5.4-mini-fast を採る理由**

- 全質問で最速。検索ありでも 2.6s / 3.3s
- 出力単価 $9/M で terra（$12/M）・gpt-4o（$10/M）より安い
- 出典が衆議院会議録（shugiin.go.jp）に絞られていて堅い

トレードオフとして、検索ありの質問で日付の精度が terra より粗くなります（「2026年7月の委員会で審議が進み」止まり）。ただしこれは主用途である「法案を分かりやすく説明する」ではなく、時事質問という周辺ケースでの差と判断しました。

## Gateway に存在しないモデルについて（別PR対応予定）

計測の過程で、`AI_MODELS` に登録済みだが Vercel AI Gateway に存在しないモデルが4つあることが分かりました。

```
openai/gpt-5-chat
openai/gpt-5.1-instant
google/gemini-3-flash-preview
google/gemini-3.1-flash-lite-preview
```

このうち `gpt-5-chat` と `gpt-5.1-instant` は admin の `CHAT_MODEL_OPTIONS` で選択可能なため、インタビュー設定でこれらを選ぶと `GatewayModelNotFoundError` でそのインタビューが動作しません。本PRのスコープ外のため別PRで対応します。

## テスト

| コマンド | 結果 |
|---|---|
| `pnpm lint` | 通過（exit 0） |
| `pnpm typecheck` | 通過（全7ワークスペース） |
| `pnpm build` | 通過 |
| `pnpm test` | 945 passed（web）/ 568 passed（admin） |
| chat統合テスト | 14 passed |

`pnpm test` で `html-encoding-sniffer` の `ERR_REQUIRE_ESM` により35ファイルが未実行になりますが、本変更の適用前後で結果が同一（109 passed / 144, 945 tests, 35 errors）であり、ローカルの Node v20.11.0 に起因する既存の事象です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - モデルが指定されていない場合に使用されるデフォルトモデルを、新しいモデルへ更新しました。
  - チャットリクエストで、より高速な新モデルによる応答が利用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->