### PR TITLE
議案本文の h4 にスタイルを当てる（本文と区別できるようにする）

### DIFF
--- a/web/src/features/bills/server/components/bill-detail/bill-content.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-content.tsx
@@ -21,6 +21,7 @@ export async function BillContent({ bill }: BillContentProps) {
             [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:mb-4
             [&_h2]:text-[22px] [&_h2]:font-bold [&_h2]:mb-4
             [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:mb-2
+            [&_h4]:text-base [&_h4]:font-bold [&_h4]:mt-6 [&_h4]:mb-2
             [&_p]:mb-4 [&_p]:leading-relaxed
             [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-4
             [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:mb-4


### PR DESCRIPTION
議案本文（記事）で `#### 見出し` を書いたときに、見出しが本文の段落とまったく同じ見た目になる問題を直します。

## 問題

`web/src/features/bills/server/components/bill-detail/bill-content.tsx` の Markdown 用スタイルは **h1 / h2 / h3 しか定義していません**。h4 は Tailwind preflight で `font-size: inherit; font-weight: inherit; margin: 0` にリセットされたまま描画されるため、記事側で 4 階層目の見出しを書くと、

- 文字サイズも太さも本文と同じ
- 上下マージンも 0 で、直前の段落に貼り付く

という状態になり、見出しとして機能しません。

実際に「青少年インターネット環境整備法の見直しに向けた中間整理報告書」の記事で、大きな論点の下の小見出し（例:「法目的・基本理念を再整理する」）が本文と区別できないという指摘がありました（政調・矢也）。

## 変更

```
[&_h4]:text-base [&_h4]:font-bold [&_h4]:mt-6 [&_h4]:mb-2
```

を 1 行追加しました。h3（18px / semibold）と本文（16px / normal）の間に入る階層として、**16px の太字 + 上マージン**で描画します。

## 影響範囲

`bills/**` の記事本文を検索した限り **h4 を使っている既存記事は 1 件もありません**（`####` は `resources/` 配下の調査メモにしかなく、これらは公開描画されません）。したがって既存記事の表示は変わらず、今後 h4 を使う記事にだけ効きます。

## 補足

- 記事側では、この修正のデプロイを待たずに済むよう、当該記事の見出しを h2 / h3 に繰り上げる対応を別途入れています（[mirai-gikai-content#633](https://github.com/team-mirai/mirai-gikai-content/pull/633)）。本 PR は「今後 h4 を使えるようにする」ためのものです。
- h5 / h6 は引き続き未定義です。記事の階層がそこまで深くなる運用は今のところ無いため、必要になった時点で足す方針としています。
- 同じ理由で **Markdown の表（GFM）も描画できません**（`remark-gfm` 未導入）。こちらは別の修正が必要で、本 PR の範囲外です。

🤖 by みらいいぬ

<!-- mirai-inu-session: sesn_016ogHQUH3xV6pARqeJtD5Dc -->
<!-- mirai-inu-provenance: runtime=cma; model=claude-opus-5 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * Markdown内の「h4」見出しに、本文サイズ、太字、上下の余白を適用しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->