### PR TITLE
AIインタビュー受付中セクションの説明文を見直す

### DIFF
--- a/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
@@ -29,9 +29,9 @@ describe("InterviewOpenBillSection", () => {
     expect(
       screen.getByRole("heading", { name: "AIインタビュー受付中" })
     ).toBeInTheDocument();
-    // 扱うのは法案だけではないので、説明文に種別を並べている。
+    // 扱うのは法案だけではないので種別を並べ、募集主体である「記事」で受ける。
     expect(
-      screen.getByText("AIインタビューで意見を募集している法案・検討会・報告書")
+      screen.getByText("法案・検討会・報告書について意見を募集中の記事")
     ).toBeInTheDocument();
     expect(screen.getByText("ガソリン税を安くする法案")).toBeInTheDocument();
   });

--- a/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
@@ -29,6 +29,10 @@ describe("InterviewOpenBillSection", () => {
     expect(
       screen.getByRole("heading", { name: "AIインタビュー受付中" })
     ).toBeInTheDocument();
+    // 扱うのは法案だけではないので、説明文に種別を並べている。
+    expect(
+      screen.getByText("AIインタビューで意見を募集している法案・検討会・報告書")
+    ).toBeInTheDocument();
     expect(screen.getByText("ガソリン税を安くする法案")).toBeInTheDocument();
   });
 

--- a/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
@@ -29,9 +29,9 @@ describe("InterviewOpenBillSection", () => {
     expect(
       screen.getByRole("heading", { name: "AIインタビュー受付中" })
     ).toBeInTheDocument();
-    // 扱うのは法案だけではないので種別を並べ、募集主体である「記事」で受ける。
+    // 募集主体は解説記事。法案以外（検討会・報告書）も載るので「法案等」で受ける。
     expect(
-      screen.getByText("法案・検討会・報告書について意見を募集中の記事")
+      screen.getByText("意見を募集している法案等の解説記事")
     ).toBeInTheDocument();
     expect(screen.getByText("ガソリン税を安くする法案")).toBeInTheDocument();
   });

--- a/web/src/features/bills/server/components/interview-open-bill-section.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.tsx
@@ -14,6 +14,9 @@ interface InterviewOpenBillSectionProps {
  *
  * 説明文はタグ別セクションの説明（「〜に関する法案」）と同じ体言止めで揃える。
  * 扱うのは法案だけではないため、載せている種別を並べて示す。
+ *
+ * 主名詞は「記事」。意見を募集しているのは解説記事であって法案や検討会自体では
+ * ないので、種別は「〜について」で受ける。
  */
 export function InterviewOpenBillSection({
   bills,
@@ -30,7 +33,7 @@ export function InterviewOpenBillSection({
           AIインタビュー受付中
         </h2>
         <p className="text-xs font-medium text-mirai-text-secondary leading-[1.67]">
-          AIインタビューで意見を募集している法案・検討会・報告書
+          法案・検討会・報告書について意見を募集中の記事
         </p>
       </div>
 

--- a/web/src/features/bills/server/components/interview-open-bill-section.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.tsx
@@ -13,10 +13,9 @@ interface InterviewOpenBillSectionProps {
  * 見出し付きで先頭にまとめて、意見を出す導線を最初に見せる。
  *
  * 説明文はタグ別セクションの説明（「〜に関する法案」）と同じ体言止めで揃える。
- * 扱うのは法案だけではないため、載せている種別を並べて示す。
  *
- * 主名詞は「記事」。意見を募集しているのは解説記事であって法案や検討会自体では
- * ないので、種別は「〜について」で受ける。
+ * 主名詞は「解説記事」。意見を募集しているのは解説記事であって法案自体では
+ * ない。また扱うのは法案だけではない（検討会や報告書もある）ため「法案等」で受ける。
  */
 export function InterviewOpenBillSection({
   bills,
@@ -33,7 +32,7 @@ export function InterviewOpenBillSection({
           AIインタビュー受付中
         </h2>
         <p className="text-xs font-medium text-mirai-text-secondary leading-[1.67]">
-          法案・検討会・報告書について意見を募集中の記事
+          意見を募集している法案等の解説記事
         </p>
       </div>
 

--- a/web/src/features/bills/server/components/interview-open-bill-section.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.tsx
@@ -8,9 +8,12 @@ interface InterviewOpenBillSectionProps {
 /**
  * トップの「AIインタビュー受付中」セクション。
  *
- * 受付中の法案はカード内のピルでしか分からず、他のセクションに散っていると
+ * 受付中の記事はカード内のピルでしか分からず、他のセクションに散っていると
  * 「今どれに意見を出せるのか」を拾うのにトップ全体を追う必要がある。
  * 見出し付きで先頭にまとめて、意見を出す導線を最初に見せる。
+ *
+ * 説明文はタグ別セクションの説明（「〜に関する法案」）と同じ体言止めで揃える。
+ * 扱うのは法案だけではないため、載せている種別を並べて示す。
  */
 export function InterviewOpenBillSection({
   bills,
@@ -27,7 +30,7 @@ export function InterviewOpenBillSection({
           AIインタビュー受付中
         </h2>
         <p className="text-xs font-medium text-mirai-text-secondary leading-[1.67]">
-          気になる法案にAIインタビューで意見を届けられます
+          AIインタビューで意見を募集している法案・検討会・報告書
         </p>
       </div>
 


### PR DESCRIPTION
## 概要

トップページ「AIインタビュー受付中」セクションの説明文を変更する。

```diff
  AIインタビュー受付中
- 気になる法案にAIインタビューで意見を届けられます
+ 意見を募集している法案等の解説記事
```

## 変更理由

### 1. 他セクションと文体が揃っていなかった

タグ別セクションの説明文はすべて体言止めで、**掲載しているものを表す名詞で終わる**（`〜に関する法案`）。

| セクション | 説明文 |
| --- | --- |
| 子育て・教育 | 子育て支援、教育政策、若者支援に関する法案 |
| 選挙・政治改革 | 選挙制度、政治改革、民主主義の強化に関する法案 |
| エネルギー・環境 | エネルギー政策、環境保護、気候変動対策に関する法案 |
| **AIインタビュー受付中（変更前）** | 気になる法案にAIインタビューで意見を届けられます |
| **AIインタビュー受付中（変更後）** | 意見を募集している法案等の解説記事 |

変更前だけ「〜できます」の常体文で、並べたときに浮いていた。

### 2. 意見を募集している主体がずれていた

意見を募集しているのは法案そのものではなく、**その解説記事**。主名詞を `解説記事` にして、募集主体と一致させた。

### 3. 「法案」だけを指していた

このセクションに載るのは法案の記事だけではなく、検討会や報告書の解説記事も含まれる。変更前の文言は法案しか想定しておらず、報告書の記事が並んだときに説明と実態が食い違うため、`法案等` で受けるようにした。

なお見出しが既に「AIインタビュー受付中」なので、説明文側で `AIインタビューで` を繰り返すのは冗長なため落とした。

## テスト

`interview-open-bill-section.test.tsx` の見出しテストに説明文のアサーションを追加した。

```
pnpm lint       ✅ exit 0
pnpm typecheck  ✅ exit 0
vitest (bills/server/components)  ✅ 9 tests
```

> [!NOTE]
> ローカルの Node は v20.11.0 で、jsdom の依存が `ERR_REQUIRE_ESM` になるため、テストは CI と同じ Node 20.19.5 で実行して確認した（既存の環境差であり本PR起因ではない）。

（R2の認証情報がこの環境に未設定のため、スクリーンショットの添付は省略しています）

🤖 Generated with [Claude Code](https://claude.com/claude-code)