### PR TITLE
AIインタビュー受付中セクションの説明文を「意見を募集している法案」にする

### DIFF
--- a/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
@@ -29,10 +29,7 @@ describe("InterviewOpenBillSection", () => {
     expect(
       screen.getByRole("heading", { name: "AIインタビュー受付中" })
     ).toBeInTheDocument();
-    // 募集主体は解説記事。法案以外（検討会・報告書）も載るので「法案等」で受ける。
-    expect(
-      screen.getByText("意見を募集している法案等の解説記事")
-    ).toBeInTheDocument();
+    expect(screen.getByText("意見を募集している法案")).toBeInTheDocument();
     expect(screen.getByText("ガソリン税を安くする法案")).toBeInTheDocument();
   });
 

--- a/web/src/features/bills/server/components/interview-open-bill-section.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.tsx
@@ -13,9 +13,6 @@ interface InterviewOpenBillSectionProps {
  * 見出し付きで先頭にまとめて、意見を出す導線を最初に見せる。
  *
  * 説明文はタグ別セクションの説明（「〜に関する法案」）と同じ体言止めで揃える。
- *
- * 主名詞は「解説記事」。意見を募集しているのは解説記事であって法案自体では
- * ない。また扱うのは法案だけではない（検討会や報告書もある）ため「法案等」で受ける。
  */
 export function InterviewOpenBillSection({
   bills,
@@ -32,7 +29,7 @@ export function InterviewOpenBillSection({
           AIインタビュー受付中
         </h2>
         <p className="text-xs font-medium text-mirai-text-secondary leading-[1.67]">
-          意見を募集している法案等の解説記事
+          意見を募集している法案
         </p>
       </div>
 


### PR DESCRIPTION
## 概要

トップページ「AIインタビュー受付中」セクションの説明文を短くする。

```diff
  AIインタビュー受付中
- 意見を募集している法案等の解説記事
+ 意見を募集している法案
```

#973 で `意見を募集している法案等の解説記事` にしたが、シンプルに `意見を募集している法案` とする。

タグ別セクションの説明文（`〜に関する法案`）と同じく体言止め・`法案` 終わりで揃う。

| セクション | 説明文 |
| --- | --- |
| **AIインタビュー受付中** | 意見を募集している法案 |
| 子育て・教育 | 子育て支援、教育政策、若者支援に関する法案 |
| 選挙・政治改革 | 選挙制度、政治改革、民主主義の強化に関する法案 |
| エネルギー・環境 | エネルギー政策、環境保護、気候変動対策に関する法案 |

あわせて #973 で入れた補足コメント（募集主体・種別についての説明）も文言に合わなくなるため削除した。

## テスト

`interview-open-bill-section.test.tsx` の説明文アサーションを更新。

```
pnpm lint       ✅ exit 0
pnpm typecheck  ✅ exit 0
vitest (bills/server/components)  ✅ 9 tests
```

> [!NOTE]
> ローカルの Node は v20.11.0 で jsdom の依存が `ERR_REQUIRE_ESM` になるため、テストは CI と同じ Node 20.19.5 で実行して確認した（既存の環境差であり本PR起因ではない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **表記変更**
  * 意見募集ページの説明文を「意見を募集している法案等の解説記事」から「意見を募集している法案」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->