### PR TITLE
AIインタビュー受付中セクションの説明文を「意見募集中のテーマ」にする

### DIFF
--- a/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.test.tsx
@@ -29,7 +29,7 @@ describe("InterviewOpenBillSection", () => {
     expect(
       screen.getByRole("heading", { name: "AIインタビュー受付中" })
     ).toBeInTheDocument();
-    expect(screen.getByText("意見を募集している法案")).toBeInTheDocument();
+    expect(screen.getByText("意見募集中のテーマ")).toBeInTheDocument();
     expect(screen.getByText("ガソリン税を安くする法案")).toBeInTheDocument();
   });
 

--- a/web/src/features/bills/server/components/interview-open-bill-section.tsx
+++ b/web/src/features/bills/server/components/interview-open-bill-section.tsx
@@ -13,6 +13,8 @@ interface InterviewOpenBillSectionProps {
  * 見出し付きで先頭にまとめて、意見を出す導線を最初に見せる。
  *
  * 説明文はタグ別セクションの説明（「〜に関する法案」）と同じ体言止めで揃える。
+ * ただし載るのは法案だけではない（検討会や報告書の解説記事もある）ので、
+ * 種別を限定しない「テーマ」で受ける。
  */
 export function InterviewOpenBillSection({
   bills,
@@ -29,7 +31,7 @@ export function InterviewOpenBillSection({
           AIインタビュー受付中
         </h2>
         <p className="text-xs font-medium text-mirai-text-secondary leading-[1.67]">
-          意見を募集している法案
+          意見募集中のテーマ
         </p>
       </div>
 


### PR DESCRIPTION
## 概要

トップページ「AIインタビュー受付中」セクションの説明文を変更する。

```diff
  AIインタビュー受付中
- 意見を募集している法案
+ 意見募集中のテーマ
```

#975 の `意見を募集している法案` から、種別を限定しない `テーマ` で受ける形にする。

このセクションには法案の記事だけでなく検討会や報告書の解説記事も並ぶため、`法案` で終わると実態と食い違う。`テーマ` にしておけば掲載する種別が増えても文言を直さずに済む。

体言止めはタグ別セクションの説明文と揃ったまま。

| セクション | 説明文 |
| --- | --- |
| **AIインタビュー受付中** | 意見募集中のテーマ |
| 子育て・教育 | 子育て支援、教育政策、若者支援に関する法案 |
| 選挙・政治改革 | 選挙制度、政治改革、民主主義の強化に関する法案 |
| エネルギー・環境 | エネルギー政策、環境保護、気候変動対策に関する法案 |

## テスト

`interview-open-bill-section.test.tsx` の説明文アサーションを更新。

```
pnpm lint       ✅ exit 0
pnpm typecheck  ✅ exit 0
vitest (bills/server/components)  ✅ 9 tests
```

> [!NOTE]
> ローカルの Node は v20.11.0 で jsdom の依存が `ERR_REQUIRE_ESM` になるため、テストは CI と同じ Node 20.19.5 で実行して確認した（既存の環境差であり本PR起因ではない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **表示改善**
  - 意見を募集している対象の見出しを「意見募集中のテーマ」に変更しました。
  - 法案に限らず、検討会や報告書などを含む、より実態に合った表現になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->