### PR TITLE
Gemini 3.1 Flash Lite Preview を Gemini 3.8 Flash に差し替える

### DIFF
--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.test.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.test.ts
@@ -29,6 +29,14 @@ describe("estimateInterviewCostUsd", () => {
     expect(cost).toBeCloseTo(0.0515, 4);
   });
 
+  it("Gemini 3.8 Flashの推定コストを正しく算出する", () => {
+    // input: 0.75 * 85000 / 1M = 0.06375
+    // output: 3.75 * 3000 / 1M = 0.01125
+    // total: 0.075
+    const cost = estimateInterviewCostUsd("google/gemini-3.8-flash");
+    expect(cost).toBeCloseTo(0.075, 4);
+  });
+
   it("GPT-5.6 Solの推定コストを正しく算出する", () => {
     // input: 5 * 85000 / 1M = 0.425
     // output: 30 * 3000 / 1M = 0.09

--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
@@ -38,6 +38,8 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
     inputPerMillion: 2,
     outputPerMillion: 12,
   },
+  // 2026-12-31 までの導入価格。期限後に見直すこと。
+  "google/gemini-3.8-flash": { inputPerMillion: 0.75, outputPerMillion: 3.75 },
   "google/gemma-4-26b-a4b-it": {
     inputPerMillion: 0.06,
     outputPerMillion: 0.33,

--- a/admin/src/features/interview-simulation/shared/constants.ts
+++ b/admin/src/features/interview-simulation/shared/constants.ts
@@ -19,10 +19,7 @@ export const SIMULATION_MODEL_OPTIONS = [
   { value: AI_MODELS.gpt4_1_mini, label: "GPT-4.1 mini" },
   { value: AI_MODELS.gemini3_flash_preview, label: "Gemini 3 Flash (preview)" },
   { value: AI_MODELS.gemini3_1_pro_preview, label: "Gemini 3.1 Pro (preview)" },
-  {
-    value: AI_MODELS.gemini3_1_flash_lite_preview,
-    label: "Gemini 3.1 Flash Lite (preview)",
-  },
+  { value: AI_MODELS.gemini3_8_flash, label: "Gemini 3.8 Flash" },
   { value: AI_MODELS.claude_sonnet_4_6, label: "Claude Sonnet 4.6" },
 ] as const;
 
@@ -30,10 +27,10 @@ export const SIMULATION_MODEL_OPTIONS = [
 export const DEFAULT_INTERVIEWER_MODEL = AI_MODELS.gpt5_2;
 
 /** インタビュイー（ペルソナ）側のデフォルトモデル */
-export const DEFAULT_INTERVIEWEE_MODEL = AI_MODELS.gemini3_1_flash_lite_preview;
+export const DEFAULT_INTERVIEWEE_MODEL = AI_MODELS.gemini3_8_flash;
 
 /** ペルソナ抽出のデフォルトモデル */
-export const DEFAULT_PERSONA_MODEL = AI_MODELS.gemini3_1_flash_lite_preview;
+export const DEFAULT_PERSONA_MODEL = AI_MODELS.gemini3_8_flash;
 
 /** AI Judge のデフォルトモデル */
 export const DEFAULT_JUDGE_MODEL = AI_MODELS.gpt5_2;

--- a/admin/src/features/topic-analysis/shared/constants.ts
+++ b/admin/src/features/topic-analysis/shared/constants.ts
@@ -10,7 +10,7 @@ export const TOPIC_ANALYSIS_MAX_CONCURRENCY = 100;
 export const TOPIC_ANALYSIS_MAX_REPRESENTATIVES = 5;
 
 /** トピック解析で使用するモデル */
-export const TOPIC_ANALYSIS_MODEL = AI_MODELS.gemini3_1_flash_lite_preview;
+export const TOPIC_ANALYSIS_MODEL = AI_MODELS.gemini3_8_flash;
 
 /** トピックレポート生成と全体サマリで使用するモデル */
 export const TOPIC_ANALYSIS_WRITING_MODEL = AI_MODELS.gemini3_flash_preview;

--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -24,8 +24,8 @@ export const AI_MODELS = {
   // --- Google ---
   gemini3_flash: "google/gemini-3-flash",
   gemini3_flash_preview: "google/gemini-3-flash-preview",
-  gemini3_1_flash_lite_preview: "google/gemini-3.1-flash-lite-preview",
   gemini3_1_pro_preview: "google/gemini-3.1-pro-preview",
+  gemini3_8_flash: "google/gemini-3.8-flash",
   gemma4_26b_a4b: "google/gemma-4-26b-a4b-it",
   // --- Anthropic ---
   claude_haiku_4_5: "anthropic/claude-haiku-4.5",

--- a/web/src/lib/ai/calculate-ai-cost.test.ts
+++ b/web/src/lib/ai/calculate-ai-cost.test.ts
@@ -58,6 +58,10 @@ describe("calculateUsageCostUsd", () => {
     expect(
       calculateUsageCostUsd(AI_MODELS.gemini3_1_pro_preview, usage)
     ).toBeCloseTo(14);
+    // Gemini 3.8 Flash: $0.75 input + $3.75 output = $4.50
+    expect(calculateUsageCostUsd(AI_MODELS.gemini3_8_flash, usage)).toBeCloseTo(
+      4.5
+    );
   });
 
   it("throws for unknown model", () => {

--- a/web/src/lib/ai/calculate-ai-cost.ts
+++ b/web/src/lib/ai/calculate-ai-cost.ts
@@ -99,6 +99,11 @@ export const modelPricing: Record<string, ModelPricing> = {
     inputTokensPerMillionUsd: 2,
     outputTokensPerMillionUsd: 12,
   },
+  // 2026-12-31 までの導入価格。期限後に見直すこと。
+  [AI_MODELS.gemini3_8_flash]: {
+    inputTokensPerMillionUsd: 0.75,
+    outputTokensPerMillionUsd: 3.75,
+  },
   [AI_MODELS.gemma4_26b_a4b]: {
     inputTokensPerMillionUsd: 0.06,
     outputTokensPerMillionUsd: 0.33,


### PR DESCRIPTION
## 概要

`google/gemini-3.1-flash-lite-preview` を `google/gemini-3.8-flash` に差し替える。

`AI_MODELS` のエントリごと差し替えたので、参照していた3箇所すべてが 3.8 Flash になる。リポジトリ内に lite-preview の参照は残っていない。

| 参照箇所 | 変更後 |
| --- | --- |
| `packages/shared/src/ai/models.ts` | `gemini3_8_flash: "google/gemini-3.8-flash"`（バージョン昇順を保つため 3.1 Pro の後ろに配置） |
| `topic-analysis/shared/constants.ts` | `TOPIC_ANALYSIS_MODEL`（トピック解析 step1〜3） |
| `interview-simulation/shared/constants.ts` | `DEFAULT_INTERVIEWEE_MODEL` / `DEFAULT_PERSONA_MODEL` / モデル選択肢（ラベルは「Gemini 3.8 Flash」） |

> [!NOTE]
> トピック解析の**執筆側**（`TOPIC_ANALYSIS_WRITING_MODEL` = step4・5 のレポート生成／全体サマリ）は `google/gemini-3-flash-preview` のままで、今回は触っていない。

## 料金の登録

lite-preview はどちらのコスト表にも未登録で、コストが **0 計上**になっていた。3.8 Flash では単価を登録する。

| ファイル | 追加内容 |
| --- | --- |
| `web/src/lib/ai/calculate-ai-cost.ts` | input `$0.75` / output `$3.75`（per 1M tokens） |
| `admin/.../estimate-interview-cost.ts` | 同上（同ファイルは「`calculate-ai-cost.ts` の modelPricing と同じ値」を保つ規約のため両方に入れる） |

導入価格（2026-12-31 まで）なので、期限後に見直す旨のコメントを両方に添えた。

出典: https://ai.google.dev/gemini-api/docs/pricing

## 影響がないことを確認した点

- **DB に保存されたモデルID**: `interview_configs.chat_model` の選択肢（`chat-model-options.ts`）に lite-preview は元々含まれておらず、既存行が孤立することはない。
- **`isKnownModel` によるバリデーション**: 使用箇所はバックフィルの引数検証のみで、DB 行の読み取り検証には使われていない。
- **使用ログの `model` カラム**: 実行時に文字列で記録するだけなので、定数の変更で過去行は壊れない。

## テスト

AIコスト計算の変更なので回帰テストを追加した（AGENTS.md のテスト方針）。

- `calculate-ai-cost.test.ts`: 1M/1M トークンで `$4.50` になること
- `estimate-interview-cost.test.ts`: 1インタビュー推定（85,000 in / 3,000 out）で `$0.075` になること

```
pnpm lint       ✅ exit 0
pnpm typecheck  ✅ exit 0
pnpm test       ✅ web 147 files / 1236 tests, admin 74/569,
                   packages/shared 16/141, topic-analysis-core 19/139
```

> [!NOTE]
> ローカルの Node は v20.11.0 で jsdom の依存が `ERR_REQUIRE_ESM` になるため、web のテストは CI と同じ Node 20.19.5 で実行して全件通過を確認した（既存の環境差であり本PR起因ではない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)